### PR TITLE
Remove GroupTransient::knowledge_ field that shadows the base one

### DIFF
--- a/src/gams/groups/GroupFixedList.h
+++ b/src/gams/groups/GroupFixedList.h
@@ -146,11 +146,6 @@ namespace gams
     protected:
 
       /**
-      * The knowledge base to use as a data plane
-      **/
-      madara::knowledge::KnowledgeBase * knowledge_;
-
-      /**
        * The source member list in the knowledge base
        **/
       madara::knowledge::containers::StringVector members_;

--- a/src/gams/groups/GroupTransient.h
+++ b/src/gams/groups/GroupTransient.h
@@ -148,11 +148,6 @@ namespace gams
     protected:
 
       /**
-      * The knowledge base to use as a data plane
-      **/
-      madara::knowledge::KnowledgeBase * knowledge_;
-
-      /**
       * The source member list in the knowledge base
       **/
       madara::knowledge::containers::Map members_;


### PR DESCRIPTION
GroupTransient contains knowledge_ field, but that is already
present in the base class as GroupBase::knowledge_, so this one
just shadows the base class one. However, inside `add_prefix`,
`GroupBase`'s methods are explicitly called, setting the GroupBase's
field.