### PR TITLE
Added using_vrep.mpb

### DIFF
--- a/scripts/projects/common/using_vrep.mpb
+++ b/scripts/projects/common/using_vrep.mpb
@@ -1,0 +1,20 @@
+feature (vrep) {
+  requires += vrep
+
+  macros += _GAMS_VREP_
+  macros += MAX_EXT_API_CONNECTIONS=255
+  macros += NON_MATLAB_PARSING
+
+  includes += $(VREP_ROOT)/programming/remoteApi
+  includes += $(VREP_ROOT)/programming/include
+
+  Header_Files {
+    $(VREP_ROOT)/programming/remoteApi/extApi.h
+    $(VREP_ROOT)/programming/remoteApi/extApiPlatform.h
+  }
+
+  Source_Files {
+    $(VREP_ROOT)/programming/remoteApi/extApi.c
+    $(VREP_ROOT)/programming/remoteApi/extApiPlatform.c
+  }
+}


### PR DESCRIPTION
Issue: gpc.pl uses common/using_vrep.mpb to copy into new project directories. It is missing from common/. This PR adds it into common.

Without this PR, users trying to do a ./action.sh compile will get the error that using_vrep.mpb is missing, and ./action.sh compile will not work.

![image](https://user-images.githubusercontent.com/1786601/44271980-8edc2e80-a209-11e8-8311-0255e9ce745d.png)
