### PR TITLE
[SW-7242] Investigate VREP simulator movement issue

### DIFF
--- a/src/gams/platforms/vrep/VREPBase.cpp
+++ b/src/gams/platforms/vrep/VREPBase.cpp
@@ -543,7 +543,7 @@ gams::platforms::VREPBase::move (const pose::Position & target,
   if (get_ready ())
   {
     // update variables
-    BasePlatform::move (target);
+    BasePlatform::move (target, bounds);
 
     madara_logger_ptr_log (gams::loggers::global_logger.get (),
       gams::loggers::LOG_TRACE,


### PR DESCRIPTION
Fixed move issue caused by recusive calls move(position)->move(position,
bounds)->move(position)