### PR TITLE
Revert "Fix for new frame loading logic"

### DIFF
--- a/src/gams/pose/ReferenceFrame.inl
+++ b/src/gams/pose/ReferenceFrame.inl
@@ -415,16 +415,9 @@ inline void transform(
           CoordType &in,
           const ReferenceFrame &to_frame)
 {
-  if (to_frame == in.frame()) {
+  if (to_frame == in.frame())
     return;
-  }
-  if (!to_frame.valid()) {
-    throw unrelated_frames(in.frame(), to_frame);
-  }
-  if (!in.frame().valid()) {
-    throw unrelated_frames(in.frame(), to_frame);
-  }
-  if (to_frame == in.frame().origin_frame())
+  else if (to_frame == in.frame().origin_frame())
   {
     transform_to_origin(in);
     in.frame(in.frame().origin_frame());

--- a/tests/test_coordinates.cpp
+++ b/tests/test_coordinates.cpp
@@ -258,18 +258,10 @@ int main(int, char *[])
   LOG(Orientation(hex6.transform_to(hex_frame0)));
   TEST(hex0.angle_to(hex0), 0);
 
-  std::cout << std::endl << "Test saving and loading frame tree:"
+  std::cout << std::endl << "Test saving and loading frame tree (TODO):"
             << std::endl;
 
   madara::knowledge::KnowledgeBase kb;
-
-  {
-    auto missing = ReferenceFrame::load(kb, "missing_frame");
-    auto missing2 = ReferenceFrame::load(kb, "missing_frame_2");
-    EXPECT_EXCEPTION(
-      unrelated_frames,
-      missing.origin().transform_to(missing2));
-  }
 
   {
     ReferenceFrame building_frame("Building", Pose{gps_frame(), 70, -40}, -1);


### PR DESCRIPTION
Reverts jredmondson/gams#46

Unfortunately, this broke test_coordinates with a segfault for all g++ builds. This is likely to cause issues with devs.