### PR TITLE
Fixed vrep not moving issue

### DIFF
--- a/scripts/projects/gpc.pl
+++ b/scripts/projects/gpc.pl
@@ -4511,6 +4511,7 @@ int main (int argc, char ** argv)
     gams::loggers::global_logger->set_level (gams_debug_level);
   }
 
+  controller_settings.eval_settings = madara::knowledge::EvalSettings::SEND;
   controllers::BaseController controller (knowledge, controller_settings);
   madara::threads::Threader threader (knowledge);
 

--- a/src/simulation/dynamic_simulation.cpp
+++ b/src/simulation/dynamic_simulation.cpp
@@ -680,7 +680,7 @@ void start_simulator (const int & client_id,
   compiled = knowledge.compile (expression);
   cout << "waiting for " << num_agents << " agent(s) to come online...";
   cout << std::flush;
-  knowledge.wait (compiled);
+  knowledge.wait (compiled, madara::knowledge::WaitSettings::SEND);
   cout << "done" << endl;
 
   knowledge.evaluate ("vrep_ready=1");


### PR DESCRIPTION
When defaults for eval settings were changed, dynamic_simulation
knowledge was waiting without send, that caused issue
Also each controller had to set own eval settings to send